### PR TITLE
增加 创建二维码 时的二维码超时参数

### DIFF
--- a/lib/alipay_f2f.js
+++ b/lib/alipay_f2f.js
@@ -66,6 +66,7 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA26kCbp+LscnLHMdwMQ0ewc29g1N3TB6YRviq
      *        必填 totalAmount(Double)          订单总金额，整形，此处单位为元，精确到小数点后2位，不能超过1亿元
      *        可填 body(String)                 订单描述，可以对交易或商品进行一个详细地描述，比如填写"购买商品2件共15.00元"
      *        可填 timeExpress(Int)             支付超时，线下扫码交易定义为5分钟
+     *        可填 qrExpress(Int)               二维码超时
      * @return {Promise}
      */
     createQRPay(option) {
@@ -75,6 +76,7 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA26kCbp+LscnLHMdwMQ0ewc29g1N3TB6YRviq
             var body = option["body"] || "";
             var totalAmount = option["totalAmount"] || "";
             var timeExpress = option["timeExpress"] || 5;
+            var qrExpress = option["qrExpress"] || 5;
 
             if (tradeNo == "") {
                 return reject({
@@ -112,6 +114,13 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA26kCbp+LscnLHMdwMQ0ewc29g1N3TB6YRviq
                 });
             }
             timeExpress = timeExpress + "m";
+            qrExpress = parseInt(qrExpress);
+            if (isNaN(qrExpress)) {
+                return reject({
+                    message: "qrExpress 参数非法.", info: null
+                });
+            }
+            qrExpress = qrExpress + "m";
 
             var alipayArrayData = {};
             alipayArrayData["subject"] = subject;
@@ -119,6 +128,7 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA26kCbp+LscnLHMdwMQ0ewc29g1N3TB6YRviq
             alipayArrayData["out_trade_no"] = tradeNo;
             alipayArrayData["total_amount"] = totalAmount;
             alipayArrayData["timeout_express"] = timeExpress;
+            alipayArrayData["qr_code_timeout_express"] = qrExpress;
 
             aop.execute("alipay.trade.precreate", this._config, alipayArrayData).then(resolve).catch(reject);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alipay-ftof",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "支付宝当面付nodejs apis",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
原本的参数timeout_express只有在用户扫码后才会生效；二维码生成到用户扫码期间并不计算timeout_express，所以增加一个qrExpress参数使二维码可控地自动失效